### PR TITLE
Bootstrap Bazel 4.0 on Ubuntu Jammy using bazel-bootstrap in docker

### DIFF
--- a/experiments/bootstrap_bazel4_on_jammy/Dockerfile
+++ b/experiments/bootstrap_bazel4_on_jammy/Dockerfile
@@ -20,7 +20,7 @@ RUN useradd -u ${uid} -g ${group} -s /bin/sh -m ${user}
 USER ${uid}:${gid}
 WORKDIR /home/buildfarm
 
-RUN wget https://github.com/bazelbuild/bazel/archive/refs/tags/4.2.3.tar.gz \
+RUN wget -q https://github.com/bazelbuild/bazel/archive/refs/tags/4.2.3.tar.gz \
     && tar xzf 4.2.3.tar.gz \
     && echo "a9ef01b744d2fdcd688dcc9ecc25ad6dffaf4a9967058303fd27a5b41670b7d7 4.2.3.tar.gz" | sha256sum -c
 WORKDIR bazel-4.2.3

--- a/experiments/bootstrap_bazel4_on_jammy/Dockerfile
+++ b/experiments/bootstrap_bazel4_on_jammy/Dockerfile
@@ -25,7 +25,7 @@ RUN wget https://github.com/bazelbuild/bazel/archive/refs/tags/4.2.3.tar.gz \
     && echo "a9ef01b744d2fdcd688dcc9ecc25ad6dffaf4a9967058303fd27a5b41670b7d7 4.2.3.tar.gz" | sha256sum -c
 WORKDIR bazel-4.2.3
 COPY patches/absl_ghrp.patch absl_ghrp.patch
-COPY pacthes/ijar.patch ijar.patch
+COPY patches/ijar.patch ijar.patch
 RUN patch -p1 < absl_ghrp.patch \
     && patch -p1 < ijar.patch
 RUN bazel build //src:bazel-dev

--- a/experiments/bootstrap_bazel4_on_jammy/Dockerfile
+++ b/experiments/bootstrap_bazel4_on_jammy/Dockerfile
@@ -1,0 +1,31 @@
+FROM ubuntu:jammy
+MAINTAINER Jose Luis Rivero <jrivero@openrobotics.org>
+ENV LANG C
+ENV LC_ALL C
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y \
+ bazel-bootstrap \
+ wget \
+ unzip \
+ zip \
+ zlib1g-dev \
+ && rm -rf /var/lib/apt/lists/*
+
+ARG user=buildfarm
+ARG group=buildfarm
+ARG uid=1000
+ARG gid=1000
+RUN groupadd -g ${gid} ${group}
+RUN useradd -u ${uid} -g ${group} -s /bin/sh -m ${user}
+USER ${uid}:${gid}
+WORKDIR /home/buildfarm
+
+RUN wget https://github.com/bazelbuild/bazel/archive/refs/tags/4.2.3.tar.gz \
+    && tar xzf 4.2.3.tar.gz \
+    && echo "a9ef01b744d2fdcd688dcc9ecc25ad6dffaf4a9967058303fd27a5b41670b7d7 4.2.3.tar.gz" | sha256sum -c
+WORKDIR bazel-4.2.3
+COPY patches/absl_ghrp.patch absl_ghrp.patch
+COPY pacthes/ijar.patch ijar.patch
+RUN patch -p1 < absl_ghrp.patch \
+    && patch -p1 < ijar.patch
+RUN bazel build //src:bazel-dev

--- a/experiments/bootstrap_bazel4_on_jammy/patches/absl_ghrp.patch
+++ b/experiments/bootstrap_bazel4_on_jammy/patches/absl_ghrp.patch
@@ -1,0 +1,49 @@
+Description: Add missing includes to abseil-cpp in order to build with gcc11
+Origin: https://gitlab.alpinelinux.org/alpine/aports/-/blob/2efd9732b4cd406ea424e5af71c915092a801e8c/testing/bazel4/patch_ftbfs_gcc11_4.patch
+Acked-by: Jose Luis Rivero <jrivero@openrobotics.org>
+
+--- a/third_party/grpc/grpc_1.33.1.patch
++++ b/third_party/grpc/grpc_1.33.1.patch
+@@ -58,6 +58,14 @@ index 09fcad95a2..9b737e5deb 100644
+      )
+  
+      native.bind(
++@@ -245,6 +245,7 @@ def grpc_deps():
++                 "https://storage.googleapis.com/grpc-bazel-mirror/github.com/abseil/abseil-cpp/archive/df3ea785d8c30a9503321a3d35ee7d35808f190d.tar.gz",
++                 "https://github.com/abseil/abseil-cpp/archive/df3ea785d8c30a9503321a3d35ee7d35808f190d.tar.gz",
++             ],
+++            patches = ["@com_github_grpc_grpc//:third_party/abseil-cpp/absl.patch"],
++         )
++
++     if "bazel_toolchains" not in native.existing_rules():
+ diff --git a/bazel/grpc_extra_deps.bzl b/bazel/grpc_extra_deps.bzl
+ index 4c1dfad2e8..f63c54ddef 100644
+ --- a/bazel/grpc_extra_deps.bzl
+@@ -120,3 +128,25 @@ index c047f0c515..7c24fbc617 100644
+          ":windows": "@com_github_grpc_grpc//third_party/cares:config_windows/ares_config.h",
+          ":android": "@com_github_grpc_grpc//third_party/cares:config_android/ares_config.h",
+          "//conditions:default": "@com_github_grpc_grpc//third_party/cares:config_linux/ares_config.h",
++
++--- /dev/null
+++++ b/third_party/abseil-cpp/absl.patch
++@@ -0,0 +1,18 @@
+++0e2c62da1dcaf6529abab952bdcc96c6de2d9506 by Abseil Team <absl-team@google.com>:
+++
+++Add missing <limits> include
+++
+++PiperOrigin-RevId: 339054753
+++
+++--
+++
+++--- absl/synchronization/internal/graphcycles.cc
++++++ absl/synchronization/internal/graphcycles.cc
+++@@ -37,6 +37,7 @@
+++ 
+++ #include <algorithm>
+++ #include <array>
++++#include <limits>
+++ #include "absl/base/internal/hide_ptr.h"
+++ #include "absl/base/internal/raw_logging.h"
+++ #include "absl/base/internal/spinlock.h"
+
+

--- a/experiments/bootstrap_bazel4_on_jammy/patches/ijar.patch
+++ b/experiments/bootstrap_bazel4_on_jammy/patches/ijar.patch
@@ -1,0 +1,36 @@
+Description: Add missing includes to ijar in order to support gcc11 build
+Origin: https://gitlab.alpinelinux.org/alpine/aports/-/blob/2efd9732b4cd406ea424e5af71c915092a801e8c/testing/bazel4/patch_ftbfs_gcc11_1.patch
+Acked-by: Jose Luis Rivero <jrivero@openrobotics.org>
+
+diff --git a/third_party/ijar/mapped_file_unix.cc b/third_party/ijar/mapped_file_unix.cc
+index 6e3a908..65179e3 100644
+--- a/third_party/ijar/mapped_file_unix.cc
++++ b/third_party/ijar/mapped_file_unix.cc
+@@ -15,10 +15,11 @@
+ #include <errno.h>
+ #include <fcntl.h>
+ #include <stdio.h>
+-#include <unistd.h>
+ #include <sys/mman.h>
++#include <unistd.h>
+ 
+ #include <algorithm>
++#include <limits>
+ 
+ #include "third_party/ijar/mapped_file.h"
+ 
+diff --git a/third_party/ijar/zlib_client.h b/third_party/ijar/zlib_client.h
+index ed66163..0a917ff 100644
+--- a/third_party/ijar/zlib_client.h
++++ b/third_party/ijar/zlib_client.h
+@@ -17,6 +17,9 @@
+ 
+ #include <limits.h>
+ 
++#include <limits>
++#include <stdexcept>
++
+ #include "third_party/ijar/common.h"
+ 
+ namespace devtools_ijar {
+(END)


### PR DESCRIPTION
# 🎉 New feature

Closes: #3 

## Summary
The PR demonstrate with a Dockerfile the ability of bootstrapping Bazel 4.0 using bazel-bootstrap package available in system Ubuntu Jammy by using a rootless account. 

## Test it
```bash
cd experiments/bootstrap_bazel4_on_jammy/
docker build . -t bazel4
```

## Checklist
- [x] Signed all commits for DCO