### PR TITLE
WIP: Dockerfile to build drake-1.12 rootless on Jammy

### DIFF
--- a/experiments/drake1.12_on_jammy/Dockerfile
+++ b/experiments/drake1.12_on_jammy/Dockerfile
@@ -139,5 +139,5 @@ RUN mkdir gen/ \
 RUN bazel clean
 RUN mkdir -p build \
     && cd build \
-    && '/usr/bin/cmake' '--warn-uninitialized' '-DCMAKE_BUILD_TYPE:STRING=Release' '-GUnix Makefiles' '-DCMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH:BOOL=False' '..' \
+    && '/usr/bin/cmake' '--warn-uninitialized' '-DCMAKE_BUILD_TYPE:STRING=Release' '-GUnix Makefiles' '..' \
     && make

--- a/experiments/drake1.12_on_jammy/Dockerfile
+++ b/experiments/drake1.12_on_jammy/Dockerfile
@@ -1,0 +1,143 @@
+FROM ubuntu:jammy
+MAINTAINER Jose Luis Rivero <jrivero@openrobotics.org>
+ENV LANG C           
+ENV LC_ALL C         
+ARG DEBIAN_FRONTEND=noninteractive 
+RUN apt-get update && apt-get install -y \
+ bazel-bootstrap \
+   clang-12 \
+   clang-format-12 \
+   cmake \
+   coinor-libclp-dev \
+   coinor-libcoinutils-dev \
+   coinor-libipopt-dev \
+   default-jdk \
+   default-jre \
+   dh-sequence-python3 \
+   dh-sequence-sphinxdoc \
+   doxygen \
+   file \
+   fonts-dejavu-core \
+   fonts-dejavu-extra \
+   gfortran \
+   git \
+   graphviz \
+   javahelper \
+   jekyll \
+   jupyter-notebook \
+   libamd2 \
+   libblas-dev \
+   libbz2-dev \
+   libclang-12-dev \
+   libcurl4-gnutls-dev \
+   libdouble-conversion-dev \
+   libeigen3-dev \
+   libexpat1-dev \
+   libfreetype6 \
+   libgflags-dev \
+   libgfortran5 \
+   libgl-dev \
+   libglew-dev \
+   libglib2.0-dev \
+   libglu1-mesa \
+   libglx-dev \
+   libhdf5-103 \
+   libjchart2d-java \
+   libjpeg-turbo8-dev \
+   libjsoncpp-dev \
+   liblapack-dev \
+   libldl2 \
+   liblz4-dev \
+   liblzma-dev \
+   libmsgpack-dev \
+   libmumps-seq-dev \
+   libnlopt-cxx-dev \
+   libogg0 \
+   libomp-12-dev \
+   libopengl-dev \
+   libpng-dev \
+   libqt5core5a \
+   libqt5gui5 \
+   libqt5printsupport5 \
+   libqt5widgets5 \
+   libquadmath0 \
+   libspdlog-dev \
+   libsqlite3-0 \
+   libsuitesparse-dev \
+   libtheora0 \
+   libtiff-dev \
+   libtinyxml-dev \
+   libtinyxml2-dev \
+   libtool \
+   libvtk9-dev \
+   libyaml-cpp-dev \
+   libx11-dev \
+   libxml2 \
+   libxt6 \
+   node-uglify \
+   ocl-icd-opencl-dev \
+   opencl-headers \
+   openssh-client \
+   patch \
+   patchelf \
+   pkg-config \
+   python-is-python3 \
+   python3-all-dev \
+   python3-docutils \
+   python3-ipywidgets \
+   python3-lxml \
+   python3-matplotlib \
+   python3-munkres \
+   python3-numpy \
+   python3-pil \
+   python3-pydot \
+   python3-pygame \
+   python3-scipy \
+   python3-semantic-version \
+   python3-sphinx \
+   python3-sphinx-rtd-theme \
+   python3-tk \
+   python3-tornado \
+   python3-u-msgpack \
+   python3-yaml \
+   python3-zmq \
+   rsync \
+   unzip \
+   wget \
+   zlib1g-dev \
+   && rm -rf /var/lib/apt/lists/*
+
+ARG user=buildfarm
+ARG group=buildfarm
+ARG uid=1000
+ARG gid=1000
+RUN groupadd -g ${gid} ${group}
+RUN useradd -u ${uid} -g ${group} -s /bin/sh -m ${user}
+USER ${uid}:${gid}
+WORKDIR /home/buildfarm
+
+RUN wget -q https://github.com/bazelbuild/bazel/archive/refs/tags/4.2.3.tar.gz \
+    && tar xzf 4.2.3.tar.gz \
+    && echo "a9ef01b744d2fdcd688dcc9ecc25ad6dffaf4a9967058303fd27a5b41670b7d7 4.2.3.tar.gz" | sha256sum -c
+WORKDIR bazel-4.2.3
+COPY patches/absl_ghrp.patch absl_ghrp.patch
+COPY patches/ijar.patch ijar.patch
+RUN patch -p1 < absl_ghrp.patch \
+    && patch -p1 < ijar.patch
+RUN bazel build //src:bazel --compilation_mode=opt
+
+RUN ./bazel-bin/src/bazel version
+RUN cp bazel-bin/src/bazel /tmp/bazel
+
+RUN wget https://github.com/RobotLocomotion/drake/archive/refs/tags/v1.12.0.tar.gz \
+  && tar xf v1.12.0.tar.gz
+WORKDIR drake-1.12.0
+RUN mkdir build \
+    && cp /tmp/bazel build/
+RUN mkdir gen/ \
+    && echo "import tools/ubuntu-jammy.bazelrc" > gen/environment.bazelrc
+RUN bazel clean
+RUN mkdir -p build \
+    && cd build \
+    && '/usr/bin/cmake' '--warn-uninitialized' '-DCMAKE_BUILD_TYPE:STRING=Release' '-GUnix Makefiles' '-DCMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH:BOOL=False' '..' \
+    && make

--- a/experiments/drake1.12_on_jammy/patches/absl_ghrp.patch
+++ b/experiments/drake1.12_on_jammy/patches/absl_ghrp.patch
@@ -1,0 +1,49 @@
+Description: Add missing includes to abseil-cpp in order to build with gcc11
+Origin: https://gitlab.alpinelinux.org/alpine/aports/-/blob/2efd9732b4cd406ea424e5af71c915092a801e8c/testing/bazel4/patch_ftbfs_gcc11_4.patch
+Acked-by: Jose Luis Rivero <jrivero@openrobotics.org>
+
+--- a/third_party/grpc/grpc_1.33.1.patch
++++ b/third_party/grpc/grpc_1.33.1.patch
+@@ -58,6 +58,14 @@ index 09fcad95a2..9b737e5deb 100644
+      )
+  
+      native.bind(
++@@ -245,6 +245,7 @@ def grpc_deps():
++                 "https://storage.googleapis.com/grpc-bazel-mirror/github.com/abseil/abseil-cpp/archive/df3ea785d8c30a9503321a3d35ee7d35808f190d.tar.gz",
++                 "https://github.com/abseil/abseil-cpp/archive/df3ea785d8c30a9503321a3d35ee7d35808f190d.tar.gz",
++             ],
+++            patches = ["@com_github_grpc_grpc//:third_party/abseil-cpp/absl.patch"],
++         )
++
++     if "bazel_toolchains" not in native.existing_rules():
+ diff --git a/bazel/grpc_extra_deps.bzl b/bazel/grpc_extra_deps.bzl
+ index 4c1dfad2e8..f63c54ddef 100644
+ --- a/bazel/grpc_extra_deps.bzl
+@@ -120,3 +128,25 @@ index c047f0c515..7c24fbc617 100644
+          ":windows": "@com_github_grpc_grpc//third_party/cares:config_windows/ares_config.h",
+          ":android": "@com_github_grpc_grpc//third_party/cares:config_android/ares_config.h",
+          "//conditions:default": "@com_github_grpc_grpc//third_party/cares:config_linux/ares_config.h",
++
++--- /dev/null
+++++ b/third_party/abseil-cpp/absl.patch
++@@ -0,0 +1,18 @@
+++0e2c62da1dcaf6529abab952bdcc96c6de2d9506 by Abseil Team <absl-team@google.com>:
+++
+++Add missing <limits> include
+++
+++PiperOrigin-RevId: 339054753
+++
+++--
+++
+++--- absl/synchronization/internal/graphcycles.cc
++++++ absl/synchronization/internal/graphcycles.cc
+++@@ -37,6 +37,7 @@
+++ 
+++ #include <algorithm>
+++ #include <array>
++++#include <limits>
+++ #include "absl/base/internal/hide_ptr.h"
+++ #include "absl/base/internal/raw_logging.h"
+++ #include "absl/base/internal/spinlock.h"
+
+

--- a/experiments/drake1.12_on_jammy/patches/ijar.patch
+++ b/experiments/drake1.12_on_jammy/patches/ijar.patch
@@ -1,0 +1,36 @@
+Description: Add missing includes to ijar in order to support gcc11 build
+Origin: https://gitlab.alpinelinux.org/alpine/aports/-/blob/2efd9732b4cd406ea424e5af71c915092a801e8c/testing/bazel4/patch_ftbfs_gcc11_1.patch
+Acked-by: Jose Luis Rivero <jrivero@openrobotics.org>
+
+diff --git a/third_party/ijar/mapped_file_unix.cc b/third_party/ijar/mapped_file_unix.cc
+index 6e3a908..65179e3 100644
+--- a/third_party/ijar/mapped_file_unix.cc
++++ b/third_party/ijar/mapped_file_unix.cc
+@@ -15,10 +15,11 @@
+ #include <errno.h>
+ #include <fcntl.h>
+ #include <stdio.h>
+-#include <unistd.h>
+ #include <sys/mman.h>
++#include <unistd.h>
+ 
+ #include <algorithm>
++#include <limits>
+ 
+ #include "third_party/ijar/mapped_file.h"
+ 
+diff --git a/third_party/ijar/zlib_client.h b/third_party/ijar/zlib_client.h
+index ed66163..0a917ff 100644
+--- a/third_party/ijar/zlib_client.h
++++ b/third_party/ijar/zlib_client.h
+@@ -17,6 +17,9 @@
+ 
+ #include <limits.h>
+ 
++#include <limits>
++#include <stdexcept>
++
+ #include "third_party/ijar/common.h"
+ 
+ namespace devtools_ijar {
+(END)


### PR DESCRIPTION
Closes #5 

:hammer_and_pick:  WIP (doesn't work out of the box)

The PR tries to build drake-1.12 on Ubuntu Jammy vanilla using rootless access. It needs to bootstrap Bazel 4.x (see work in #3). Currently is failing since drake CMake system needs to find the bootstrapped Bazel 4.x instead the system see #5 
